### PR TITLE
Don't run the value of KAFKA_BROKER_ID and KAFKA_PORT when enforcing default values

### DIFF
--- a/3.3/scripts/configure-kafka.sh
+++ b/3.3/scripts/configure-kafka.sh
@@ -2,8 +2,8 @@
 
 # set -eo pipefail
 
-${KAFKA_BROKER_ID:=-1}
-${KAFKA_PORT:=9092}
+: ${KAFKA_BROKER_ID:=-1}
+KAFKA_PORT="${KAFKA_PORT:-9092}"
 
 if [[ -z "$KAFKA_LOG_DIRS" ]]; then
     export KAFKA_LOG_DIRS="/kafka/kafka-logs/$HOSTNAME"


### PR DESCRIPTION
Showing 2 alternatives to enforce defaults for ENV variables that do not then attempt to run the command contained in the variable.